### PR TITLE
chore(go): use go 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To be Released
 
+* chore(go): use go 1.17
 * chore(deps): bump github.com/rollbar/rollbar-go from 1.4.0 to 1.4.2
 
 ## 1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/logrus-rollbar
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Scalingo/errgo-rollbar v0.2.0
@@ -9,3 +9,5 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/errgo.v1 v1.0.1
 )
+
+require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect


### PR DESCRIPTION
The fix for CVE-2022-29526 is only available in Go 1.17 and 1.18.