### PR TITLE
build: update Go from 1.20 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/logrus-rollbar
 
-go 1.20
+go 1.22
 
 require (
 	github.com/Scalingo/errgo-rollbar v0.2.1


### PR DESCRIPTION
I'm preparing a new release. Longtime with no release here.